### PR TITLE
Fix auth header drift, add HMAC signing, real rate limiting, and bounded retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage.xml
 
 # macOS noise
 .DS_Store
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,40 @@ All notable changes to this project will be documented in this file. This format
 
 ## [Unreleased]
 
-- Nothing yet.
+### Added
+
+- HMAC request signing: pass `secret_key` and `client_id` to `FiriAPI` to sign
+  requests for access keys whose security level requires it beyond plain
+  API-key auth. Adds a `firi-user-signature` header, a `firi-user-clientid`
+  header, and `timestamp`/`validity` query parameters. `validity_ms` (default
+  `2000`) controls the signed timestamp's validity window; `hmac_compact_json`
+  (default `True`) controls whether the JSON body is serialized compactly
+  before signing, since Firi's own reference examples disagree on spacing.
+- Automatic retries for `GET`, `HEAD`, and `DELETE` requests on `429`, `500`,
+  `502`, `503`, and `504` responses and on transport errors, with exponential
+  backoff and jitter (honoring `Retry-After` when present). Configurable via
+  `max_retries` (default `2`), `backoff_base` (default `0.5`), and
+  `max_backoff` (default `30.0`). `POST` requests are never auto-retried,
+  since placing an order is not idempotent.
+- `FiriAuthError` and `FiriRateLimitError`, new subclasses of `FiriHTTPError`
+  for 401/403 and 429 responses respectively. `FiriRateLimitError` carries a
+  `retry_after` attribute.
+- `error_name` attribute on `FiriHTTPError`: Firi's machine-readable error code
+  from the response body's `"name"` field (e.g. `ApiKeyNotFound`,
+  `SecurityLevelTooLow`), when available.
+
+### Changed
+
+- `post_orders` signature clarified to `(market, ordertype, price, amount)`;
+  `ordertype` is mapped to the API's `type` field internally.
+- The auth header is now sent as `firi-access-key` (Firi's current documented
+  header name), with `miraiex-access-key` sent alongside for backward
+  compatibility.
+- `rate_limit` is now a true minimum-interval pacing gate rather than an
+  unconditional pre-request sleep: concurrent calls are serialized through a
+  lock to respect the interval instead of all sleeping in parallel.
+- Clarified that `MAX_COUNT` (10,000) is a firipy client-side guardrail, not a
+  limit enforced by the Firi API itself.
 
 ## [1.1.0] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -37,16 +37,72 @@ async def main():
 asyncio.run(main())
 ```
 
+## 🔑 Authentication
+
+The API key is sent as the `firi-access-key` header (Firi's current documented
+header name). `miraiex-access-key` is sent alongside it for backward
+compatibility with older integrations.
+
 ## ⏳ Rate Limiting
 
-Built-in client-side pacing (seconds to sleep before each request). Default is 1 second:
+Built-in client-side pacing (seconds to wait between requests). Default is 1 second:
 
 ```python
-client = FiriAPI("your-api-key", rate_limit=2)    # 2 second delay
-client = FiriAPI("your-api-key", rate_limit=0)    # no delay
+client = FiriAPI("your-api-key", rate_limit=2)    # min. 2 seconds between requests
+client = FiriAPI("your-api-key", rate_limit=0)    # no pacing
 ```
 
+`rate_limit` is a minimum-interval gate, not a fixed pre-request sleep. Concurrent
+calls share a lock and queue up to respect the interval, so they don't all sleep
+in parallel and burst through together the moment their individual delays expire.
 Uses `asyncio.sleep` so it won't block the event loop.
+
+## 🔁 Retries
+
+GET, HEAD, and DELETE requests retry automatically on 429, 500, 502, 503, and 504
+responses, and on transport-level errors (connection failures, timeouts):
+
+```python
+client = FiriAPI("your-api-key", max_retries=2, backoff_base=0.5, max_backoff=30.0)
+```
+
+- `max_retries` (default `2`): number of retry attempts before the error is raised.
+- `backoff_base` (default `0.5`): base seconds for exponential backoff, with jitter added.
+- `max_backoff` (default `30.0`): cap on the backoff delay.
+
+If the response carries a `Retry-After` header, that value is used instead of the
+computed backoff.
+
+POST requests never retry automatically. Placing an order isn't idempotent, so a
+retried POST after a timeout could submit the same order twice; that decision is
+left to the caller.
+
+## 🔐 HMAC Request Signing
+
+Some Firi access keys require a security level beyond plain API-key auth. For
+those, pass `secret_key` and `client_id` alongside `api_key`:
+
+```python
+client = FiriAPI(
+    "your-api-key",
+    secret_key="your-secret-key",
+    client_id="your-client-id",
+)
+```
+
+When both are set, every request is signed: a `firi-user-signature` header and a
+`firi-user-clientid` header are added, along with `timestamp` and `validity`
+query parameters. `secret_key` and `client_id` must be given together, or not at
+all.
+
+Two extra options tune the signing:
+
+- `validity_ms` (default `2000`): how long, in milliseconds, the signed timestamp
+  stays valid.
+- `hmac_compact_json` (default `True`): whether the JSON body is serialized
+  without extra whitespace before signing. Firi's own reference examples don't
+  agree on spacing, so this is exposed in case a given endpoint expects the
+  non-compact form.
 
 ## 🚩 Error Handling
 
@@ -56,6 +112,12 @@ Structured exceptions are raised by default:
 |---|---|
 | `FiriAPIError` | Base class for client errors |
 | `FiriHTTPError` | Non-success HTTP responses (status >= 400) |
+| `FiriAuthError` | Subclass of `FiriHTTPError` for authentication/authorization failures (401/403) |
+| `FiriRateLimitError` | Subclass of `FiriHTTPError` for 429 responses; carries a `retry_after` attribute (seconds, if the API supplied one) |
+
+`FiriHTTPError` also carries an `error_name` attribute: Firi's machine-readable
+error code from the response body's `"name"` field (e.g. `ApiKeyNotFound`,
+`SecurityLevelTooLow`), when the API provides one.
 
 Suppress exceptions with `raise_on_error=False`:
 
@@ -92,14 +154,14 @@ Error dict shape: `{"error": str, "status": int | None}`.
 | `orders_market_history(m, count=)` | `/v2/orders/{m}/history` | Closed orders (market) | `count` |
 | `orders_history(count=)` | `/v2/orders/history` | Closed orders | `count` |
 | `order(order_id)` | `/v2/order/{id}` | Get order | -- |
-| `post_orders(market, type, price, amount)` | `/v2/orders` | Create order | -- |
+| `post_orders(market, ordertype, price, amount)` | `/v2/orders` | Create order | -- |
 | `delete_orders()` | `/v2/orders` | Cancel all orders | -- |
 | `delete_orders_for_market(market)` | `/v2/orders/{market}` | Cancel market orders | -- |
 | `delete_order_detailed(order_id, market=)` | `/v2/orders/{id}/detailed` | Cancel + matched amt | `market` |
 | `coin_address(symbol)` | `/v2/{symbol}/address` | Coin deposit address | -- |
 | `coin_withdraw_pending(symbol)` | `/v2/{symbol}/withdraw/pending` | Pending withdrawals | -- |
 
-Default `count` is 500 (`DEFAULT_COUNT`). A warning is emitted above `MAX_COUNT` (10,000).
+Default `count` is 500 (`DEFAULT_COUNT`). A warning is emitted above `MAX_COUNT` (10,000); this is a firipy client-side guardrail, not a limit enforced by the Firi API itself.
 
 ### Generic Coin Helpers
 

--- a/src/firipy/__init__.py
+++ b/src/firipy/__init__.py
@@ -1,5 +1,11 @@
 """Async Python client for the Firi cryptocurrency exchange API."""
 
-from .api import FiriAPI, FiriAPIError, FiriHTTPError
+from .api import FiriAPI, FiriAPIError, FiriAuthError, FiriHTTPError, FiriRateLimitError
 
-__all__ = ["FiriAPI", "FiriAPIError", "FiriHTTPError"]
+__all__ = [
+    "FiriAPI",
+    "FiriAPIError",
+    "FiriAuthError",
+    "FiriHTTPError",
+    "FiriRateLimitError",
+]

--- a/src/firipy/_hmac.py
+++ b/src/firipy/_hmac.py
@@ -1,0 +1,47 @@
+"""HMAC request signing for Firi's ``HMAC_encrypted_secretKey`` auth scheme.
+
+Firi authenticates private endpoints by having the client sign a JSON payload
+(timestamp, validity window, and the request body) with the user's secret
+key using HMAC-SHA256, then send the hex digest and the payload fields as
+headers/params alongside the request.
+"""
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+SIGNATURE_HEADER = "firi-user-signature"
+CLIENT_ID_HEADER = "firi-user-clientid"
+
+
+def sign_request(
+    secret_key: str,
+    *,
+    validity_ms: int = 2000,
+    body: dict[str, Any] | None = None,
+    timestamp: int | None = None,
+    compact: bool = True,
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Sign a Firi request payload and return (headers, params).
+
+    ``compact`` controls JSON separator whitespace. Firi's own Node and
+    Kotlin reference samples disagree on this (compact vs spaced), so it is
+    exposed here in case a given endpoint requires the non-compact form.
+    """
+    ts = str(timestamp if timestamp is not None else int(time.time()))
+    validity = str(validity_ms)
+
+    payload: dict[str, str] = {"timestamp": ts, "validity": validity}
+    if body:
+        payload.update({key: str(value) for key, value in body.items()})
+
+    separators = (",", ":") if compact else (", ", ":")
+    encoded = json.dumps(payload, separators=separators)
+
+    signature = hmac.new(
+        secret_key.encode(), encoded.encode(), hashlib.sha256
+    ).hexdigest()
+
+    return {SIGNATURE_HEADER: signature}, {"timestamp": ts, "validity": validity}

--- a/src/firipy/api.py
+++ b/src/firipy/api.py
@@ -326,9 +326,7 @@ class FiriAPI:
                 return
             except ValueError:
                 pass
-        delay = random.uniform(
-            0, min(self.backoff_base * 2**attempt, self.max_backoff)
-        )
+        delay = random.uniform(0, min(self.backoff_base * 2**attempt, self.max_backoff))
         await asyncio.sleep(delay)
 
     async def get(self, endpoint: str, **kwargs: Any) -> JSON:

--- a/src/firipy/api.py
+++ b/src/firipy/api.py
@@ -1,18 +1,34 @@
 """Async Firi API client built on ``httpx.AsyncClient``."""
 
+import asyncio
 import logging
+import random
 import warnings
-from asyncio import sleep
 from collections.abc import Iterable
+from time import monotonic
 from typing import Any
 
 import httpx
 
-__all__ = ["FiriAPI", "FiriAPIError", "FiriHTTPError"]
+from ._hmac import CLIENT_ID_HEADER, sign_request
+
+__all__ = [
+    "FiriAPI",
+    "FiriAPIError",
+    "FiriAuthError",
+    "FiriHTTPError",
+    "FiriRateLimitError",
+]
 
 log = logging.getLogger(__name__)
 
 type JSON = dict[str, Any] | list[Any]
+
+ACCESS_KEY_HEADER = "firi-access-key"
+LEGACY_ACCESS_KEY_HEADER = "miraiex-access-key"
+
+RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "DELETE"})
 
 
 class FiriAPIError(Exception):
@@ -25,6 +41,7 @@ class FiriHTTPError(FiriAPIError):
     Attributes:
         status_code: HTTP status code from the failed response.
         payload: Parsed JSON body from the error response, if available.
+        error_name: The API's machine-readable error name, if available.
     """
 
     def __init__(
@@ -32,10 +49,38 @@ class FiriHTTPError(FiriAPIError):
         status_code: int,
         message: str,
         payload: Any | None = None,
+        error_name: str | None = None,
     ):
-        super().__init__(f"{status_code}: {message}")
+        if error_name:
+            super().__init__(f"{status_code} {error_name}: {message}")
+        else:
+            super().__init__(f"{status_code}: {message}")
         self.status_code = status_code
         self.payload = payload
+        self.error_name = error_name
+
+
+class FiriAuthError(FiriHTTPError):
+    """Raised for authentication/authorization failures (401/403)."""
+
+
+class FiriRateLimitError(FiriHTTPError):
+    """Raised when the API responds with 429 Too Many Requests.
+
+    Attributes:
+        retry_after: Seconds to wait before retrying, if the API supplied one.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        payload: Any | None = None,
+        error_name: str | None = None,
+        retry_after: float | None = None,
+    ):
+        super().__init__(status_code, message, payload, error_name)
+        self.retry_after = retry_after
 
 
 class FiriAPI:
@@ -67,29 +112,57 @@ class FiriAPI:
         timeout: float = 10.0,
         raise_on_error: bool = True,
         client: httpx.AsyncClient | None = None,
+        secret_key: str | None = None,
+        client_id: str | None = None,
+        validity_ms: int = 2000,
+        hmac_compact_json: bool = True,
+        max_retries: int = 2,
+        backoff_base: float = 0.5,
+        max_backoff: float = 30.0,
     ):
+        if (secret_key is None) != (client_id is None):
+            raise ValueError(
+                "secret_key and client_id must be given together or not at all."
+            )
         self.apiurl = base_url.rstrip("/")
         # Track ownership so we only close clients we created ourselves.
         self._owns_client = client is None
         if client is None:
             self.client = httpx.AsyncClient(
-                headers={"miraiex-access-key": api_key},
+                headers={
+                    ACCESS_KEY_HEADER: api_key,
+                    LEGACY_ACCESS_KEY_HEADER: api_key,
+                },
                 timeout=timeout,
+                limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
             )
         else:
             # Caller owns this client and is responsible for auth headers.
             # Fail fast if the required auth header is absent rather than
             # letting requests silently return 401s at call time.
-            if "miraiex-access-key" not in client.headers:
+            if (
+                ACCESS_KEY_HEADER not in client.headers
+                and LEGACY_ACCESS_KEY_HEADER not in client.headers
+            ):
                 raise ValueError(
-                    "Injected client is missing the 'miraiex-access-key' header. "
-                    "Set it before passing the client to FiriAPI, or omit 'client' "
-                    "and pass 'api_key' to let FiriAPI create its own client."
+                    f"Injected client is missing the '{ACCESS_KEY_HEADER}' (or "
+                    f"legacy '{LEGACY_ACCESS_KEY_HEADER}') header. Set one before "
+                    "passing the client to FiriAPI, or omit 'client' and pass "
+                    "'api_key' to let FiriAPI create its own client."
                 )
             self.client = client
         self.rate_limit = rate_limit
         self.timeout = timeout
         self.raise_on_error = raise_on_error
+        self.secret_key = secret_key
+        self.client_id = client_id
+        self.validity_ms = validity_ms
+        self.hmac_compact_json = hmac_compact_json
+        self.max_retries = max_retries
+        self.backoff_base = backoff_base
+        self.max_backoff = max_backoff
+        self._pace_lock = asyncio.Lock()
+        self._next_allowed_at: float = 0.0
 
     # --- Context manager helpers -------------------------------------------
 
@@ -128,6 +201,16 @@ class FiriAPI:
 
     # --- Core HTTP ---------------------------------------------------------
 
+    async def _acquire_slot(self) -> None:
+        """Block until the client-side pacing interval has elapsed."""
+        if self.rate_limit <= 0:
+            return
+        async with self._pace_lock:
+            wait = self._next_allowed_at - monotonic()
+            if wait > 0:
+                await asyncio.sleep(wait)
+            self._next_allowed_at = monotonic() + self.rate_limit
+
     async def _request(self, method: str, endpoint: str, **kwargs: Any) -> JSON:
         """Send an HTTP request and return parsed JSON.
 
@@ -136,47 +219,117 @@ class FiriAPI:
             error occurs, a dict with keys ``error`` and ``status`` is
             returned instead.
         """
-        if self.rate_limit > 0:
-            await sleep(self.rate_limit)
         url = self.apiurl + endpoint
-        try:
-            response = await self.client.request(method, url, **kwargs)
-            response.raise_for_status()
-        except httpx.HTTPStatusError as http_err:
-            status_code = http_err.response.status_code
-            payload: Any | None = None
-            try:
-                payload = http_err.response.json()
-            except Exception:  # pragma: no cover
-                payload = None
-            message = None
-            if isinstance(payload, dict):
-                message = payload.get("message") or payload.get("error")
-            if not message:
-                message = str(http_err)
-            if self.raise_on_error:
-                raise FiriHTTPError(status_code, message, payload) from http_err
-            log.warning(
-                "HTTP error (%s) for %s %s: %s",
-                status_code,
-                method,
-                url,
-                message,
+
+        if self.secret_key is not None and self.client_id is not None:
+            sig_headers, sig_params = sign_request(
+                self.secret_key,
+                body=kwargs.get("json"),
+                compact=self.hmac_compact_json,
+                validity_ms=self.validity_ms,
             )
-            return {"error": message, "status": status_code}
-        except httpx.HTTPError as err:
-            if self.raise_on_error:
-                raise FiriAPIError(str(err)) from err
-            log.error("Request error for %s %s: %s", method, url, err)
-            return {"error": str(err), "status": None}
-        else:
+            headers = dict(kwargs.get("headers") or {})
+            headers.update(sig_headers)
+            headers[CLIENT_ID_HEADER] = self.client_id
+            kwargs["headers"] = headers
+
+            params = dict(kwargs.get("params") or {})
+            for key, value in sig_params.items():
+                params.setdefault(key, value)
+            kwargs["params"] = params
+
+        method_upper = method.upper()
+        retryable = method_upper in IDEMPOTENT_METHODS
+        attempt = 0
+        while True:
+            await self._acquire_slot()
             try:
-                return response.json()
-            except ValueError:  # pragma: no cover
-                return {
-                    "error": "Invalid JSON in response",
-                    "status": response.status_code,
-                }
+                response = await self.client.request(method, url, **kwargs)
+                response.raise_for_status()
+            except httpx.HTTPStatusError as http_err:
+                status_code = http_err.response.status_code
+                if (
+                    retryable
+                    and status_code in RETRYABLE_STATUS
+                    and attempt < self.max_retries
+                ):
+                    await self._sleep_before_retry(http_err.response, attempt)
+                    attempt += 1
+                    continue
+                payload: Any | None = None
+                try:
+                    payload = http_err.response.json()
+                except ValueError:
+                    payload = None
+                message = None
+                error_name = None
+                if isinstance(payload, dict):
+                    message = payload.get("message") or payload.get("error")
+                    error_name = payload.get("name")
+                if not message:
+                    message = str(http_err)
+                if self.raise_on_error:
+                    exc_cls: type[FiriHTTPError] = FiriHTTPError
+                    if status_code in (401, 403):
+                        exc_cls = FiriAuthError
+                    elif status_code == 429:
+                        retry_after = http_err.response.headers.get("Retry-After")
+                        raise FiriRateLimitError(
+                            status_code,
+                            message,
+                            payload,
+                            error_name,
+                            float(retry_after) if retry_after else None,
+                        ) from http_err
+                    raise exc_cls(
+                        status_code, message, payload, error_name
+                    ) from http_err
+                log.warning(
+                    "HTTP error (%s) for %s %s: %s",
+                    status_code,
+                    method,
+                    url,
+                    message,
+                )
+                return {"error": message, "status": status_code}
+            except httpx.TransportError as err:
+                if retryable and attempt < self.max_retries:
+                    await self._sleep_before_retry(None, attempt)
+                    attempt += 1
+                    continue
+                if self.raise_on_error:
+                    raise FiriAPIError(str(err)) from err
+                log.error("Request error for %s %s: %s", method, url, err)
+                return {"error": str(err), "status": None}
+            except httpx.HTTPError as err:
+                if self.raise_on_error:
+                    raise FiriAPIError(str(err)) from err
+                log.error("Request error for %s %s: %s", method, url, err)
+                return {"error": str(err), "status": None}
+            else:
+                try:
+                    return response.json()
+                except ValueError:  # pragma: no cover
+                    return {
+                        "error": "Invalid JSON in response",
+                        "status": response.status_code,
+                    }
+
+    async def _sleep_before_retry(
+        self, response: httpx.Response | None, attempt: int
+    ) -> None:
+        """Sleep before a retry, honoring ``Retry-After`` if present."""
+        retry_after = response.headers.get("Retry-After") if response else None
+        if retry_after:
+            try:
+                await asyncio.sleep(float(retry_after))
+                return
+            except ValueError:
+                pass
+        delay = random.uniform(
+            0, min(self.backoff_base * 2**attempt, self.max_backoff)
+        )
+        await asyncio.sleep(delay)
 
     async def get(self, endpoint: str, **kwargs: Any) -> JSON:
         """Send a GET request to the given endpoint."""

--- a/tests/test_firipy.py
+++ b/tests/test_firipy.py
@@ -1,10 +1,19 @@
 """Unit tests for :mod:`firipy` using ``respx`` to mock HTTP calls."""
 
+import asyncio
+import time
+
 import httpx
 import pytest
 import respx
 
 from firipy import FiriAPI, FiriAPIError, FiriHTTPError
+from firipy.api import (
+    ACCESS_KEY_HEADER,
+    LEGACY_ACCESS_KEY_HEADER,
+    FiriAuthError,
+    FiriRateLimitError,
+)
 
 API_KEY = "test-api-key"
 BASE_URL = "https://api.firi.com"
@@ -238,3 +247,147 @@ async def test_per_coin_helpers_emit_deprecation_warning(
     respx.get(f"{BASE_URL}{endpoint}").mock(return_value=httpx.Response(200, json={}))
     with pytest.warns(DeprecationWarning):
         await getattr(api, method_name)()
+
+
+async def test_self_created_client_has_both_access_key_headers() -> None:
+    """A self-created client must send both current and legacy auth headers."""
+    api = FiriAPI(API_KEY, rate_limit=0)
+    assert api.client.headers[ACCESS_KEY_HEADER] == API_KEY
+    assert api.client.headers[LEGACY_ACCESS_KEY_HEADER] == API_KEY
+    await api.aclose()
+
+
+async def test_injected_client_with_only_legacy_header_is_accepted() -> None:
+    """Injecting a client with only the legacy header must not raise."""
+    inner = httpx.AsyncClient(headers={LEGACY_ACCESS_KEY_HEADER: API_KEY})
+    api = FiriAPI(API_KEY, rate_limit=0, client=inner)
+    assert api.client is inner
+    await inner.aclose()
+
+
+@respx.mock
+async def test_first_request_not_delayed() -> None:
+    """The first request must not be delayed by the pacing gate."""
+    respx.get(f"{BASE_URL}/time").mock(
+        return_value=httpx.Response(200, json={"serverTime": "now"})
+    )
+    client = FiriAPI(API_KEY, rate_limit=0.2, base_url=BASE_URL)
+    start = time.monotonic()
+    await client.time()
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.15
+    await client.aclose()
+
+
+@respx.mock
+async def test_concurrent_requests_are_paced() -> None:
+    """Concurrent requests must be serialized by the pacing gate, not parallel."""
+    respx.get(f"{BASE_URL}/time").mock(
+        return_value=httpx.Response(200, json={"serverTime": "now"})
+    )
+    client = FiriAPI(API_KEY, rate_limit=0.05, base_url=BASE_URL)
+    start = time.monotonic()
+    await asyncio.gather(client.time(), client.time(), client.time())
+    elapsed = time.monotonic() - start
+    assert elapsed >= 0.08
+    await client.aclose()
+
+
+@respx.mock
+async def test_get_retries_once_after_503() -> None:
+    """A GET returning 503 then 200 must succeed after one retry."""
+    route = respx.get(f"{BASE_URL}/v2/markets").mock(
+        side_effect=[
+            httpx.Response(503, json={"message": "unavailable"}),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    client = FiriAPI(
+        API_KEY, rate_limit=0, base_url=BASE_URL, max_retries=2, backoff_base=0.01
+    )
+    result = await client.get("/v2/markets")
+    assert result == {"ok": True}
+    assert route.call_count == 2
+    await client.aclose()
+
+
+@respx.mock
+async def test_get_honors_retry_after_on_429() -> None:
+    """A 429 with a numeric Retry-After header must be honored on retry."""
+    route = respx.get(f"{BASE_URL}/v2/markets").mock(
+        side_effect=[
+            httpx.Response(
+                429, json={"message": "too many"}, headers={"Retry-After": "0"}
+            ),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    client = FiriAPI(
+        API_KEY, rate_limit=0, base_url=BASE_URL, max_retries=2, backoff_base=0.01
+    )
+    result = await client.get("/v2/markets")
+    assert result == {"ok": True}
+    assert route.call_count == 2
+    await client.aclose()
+
+
+@respx.mock
+async def test_get_raises_rate_limit_error_when_retries_exhausted() -> None:
+    """Persistent 429s must eventually raise FiriRateLimitError."""
+    route = respx.get(f"{BASE_URL}/v2/markets").mock(
+        return_value=httpx.Response(
+            429, json={"message": "too many"}, headers={"Retry-After": "0"}
+        )
+    )
+    client = FiriAPI(
+        API_KEY, rate_limit=0, base_url=BASE_URL, max_retries=1, backoff_base=0.01
+    )
+    with pytest.raises(FiriRateLimitError):
+        await client.get("/v2/markets")
+    assert route.call_count == 2
+    await client.aclose()
+
+
+@respx.mock
+async def test_post_503_is_not_retried() -> None:
+    """POST is not idempotent and must not be retried on 503."""
+    route = respx.post(f"{BASE_URL}/v2/orders").mock(
+        return_value=httpx.Response(503, json={"message": "unavailable"})
+    )
+    client = FiriAPI(
+        API_KEY, rate_limit=0, base_url=BASE_URL, max_retries=2, backoff_base=0.01
+    )
+    with pytest.raises(FiriHTTPError):
+        await client.post_orders("BTCNOK", "limit", "500000", "0.01")
+    assert route.call_count == 1
+    await client.aclose()
+
+
+@respx.mock
+async def test_get_raises_http_error_after_retries_exhausted() -> None:
+    """Persistent 503s must raise FiriHTTPError after max_retries+1 attempts."""
+    route = respx.get(f"{BASE_URL}/v2/markets").mock(
+        return_value=httpx.Response(503, json={"message": "unavailable"})
+    )
+    client = FiriAPI(
+        API_KEY, rate_limit=0, base_url=BASE_URL, max_retries=2, backoff_base=0.01
+    )
+    with pytest.raises(FiriHTTPError):
+        await client.get("/v2/markets")
+    assert route.call_count == 3
+    await client.aclose()
+
+
+@respx.mock
+async def test_auth_error_exposes_error_name() -> None:
+    """A 401 with a machine-readable error name must raise FiriAuthError."""
+    respx.get(f"{BASE_URL}/v2/markets").mock(
+        return_value=httpx.Response(
+            401, json={"name": "ApiKeyNotFound", "message": "Invalid API key"}
+        )
+    )
+    client = FiriAPI(API_KEY, rate_limit=0, base_url=BASE_URL)
+    with pytest.raises(FiriAuthError) as exc_info:
+        await client.get("/v2/markets")
+    assert exc_info.value.error_name == "ApiKeyNotFound"
+    await client.aclose()

--- a/tests/test_hmac.py
+++ b/tests/test_hmac.py
@@ -1,0 +1,66 @@
+"""Unit tests for :mod:`firipy._hmac`."""
+
+import hashlib
+import hmac
+import json
+
+from firipy._hmac import CLIENT_ID_HEADER, SIGNATURE_HEADER, sign_request
+
+SECRET = "test-secret"
+TIMESTAMP = 1700000000
+
+
+def _expected_signature(payload: dict[str, str], *, compact: bool) -> str:
+    separators = (",", ":") if compact else (", ", ":")
+    encoded = json.dumps(payload, separators=separators)
+    return hmac.new(SECRET.encode(), encoded.encode(), hashlib.sha256).hexdigest()
+
+
+def test_sign_request_get_style_no_body() -> None:
+    headers, params = sign_request(SECRET, timestamp=TIMESTAMP)
+
+    expected_payload = {"timestamp": str(TIMESTAMP), "validity": "2000"}
+    expected_signature = _expected_signature(expected_payload, compact=True)
+
+    assert headers[SIGNATURE_HEADER] == expected_signature
+    assert params == expected_payload
+    assert all(isinstance(v, str) for v in headers.values())
+    assert all(isinstance(v, str) for v in params.values())
+    assert params["validity"] == "2000"
+
+
+def test_sign_request_post_orders_with_body() -> None:
+    body = {"market": "BTCNOK", "price": "1000", "amount": "1", "type": "ask"}
+    headers, params = sign_request(SECRET, body=body, timestamp=TIMESTAMP)
+
+    expected_payload = {"timestamp": str(TIMESTAMP), "validity": "2000", **body}
+    expected_signature = _expected_signature(expected_payload, compact=True)
+
+    assert headers[SIGNATURE_HEADER] == expected_signature
+    assert params == {"timestamp": str(TIMESTAMP), "validity": "2000"}
+    assert all(isinstance(v, str) for v in headers.values())
+    assert all(isinstance(v, str) for v in params.values())
+
+
+def test_sign_request_compact_vs_spaced_differ() -> None:
+    body = {"market": "BTCNOK", "price": "1000", "amount": "1", "type": "ask"}
+
+    compact_headers, compact_params = sign_request(
+        SECRET, body=body, timestamp=TIMESTAMP, compact=True
+    )
+    spaced_headers, spaced_params = sign_request(
+        SECRET, body=body, timestamp=TIMESTAMP, compact=False
+    )
+
+    expected_payload = {"timestamp": str(TIMESTAMP), "validity": "2000", **body}
+    expected_compact = _expected_signature(expected_payload, compact=True)
+    expected_spaced = _expected_signature(expected_payload, compact=False)
+
+    assert compact_headers[SIGNATURE_HEADER] == expected_compact
+    assert spaced_headers[SIGNATURE_HEADER] == expected_spaced
+    assert compact_headers[SIGNATURE_HEADER] != spaced_headers[SIGNATURE_HEADER]
+    assert compact_params == spaced_params
+
+
+def test_client_id_header_constant_exists() -> None:
+    assert CLIENT_ID_HEADER == "firi-user-clientid"


### PR DESCRIPTION
## What this does

**Auth header fix.** firipy was sending `miraiex-access-key`, a legacy header name. Firi's current docs specify `firi-access-key`. This PR sends both, so it works regardless of which one the API actually checks.

**Optional HMAC signing.** Some access keys have a security level that requires request signing on top of the plain API key. Added `secret_key`, `client_id`, `validity_ms`, and `hmac_compact_json` as optional constructor params (`src/firipy/_hmac.py`). Verified live against `api.firi.com/v2/balances` with real credentials: the correct payload format is compact JSON serialized the way `JSON.stringify` would do it. Firi's own reference examples disagree with each other on this point, so this was confirmed empirically rather than from docs.

**Real rate limiting.** The old limiter slept a fixed amount before every request, which does nothing once you have concurrent calls in flight. Replaced it with a monotonic min-interval pacing gate that actually enforces spacing between requests regardless of caller concurrency.

**Retry with backoff.** GET, HEAD, and DELETE now retry with bounded exponential backoff and jitter on 429, 5xx, and transport errors, honoring `Retry-After` when present. POST is excluded on purpose: order placement isn't idempotent, so silently retrying it is the wrong default.

**Structured errors.** Added `FiriAuthError` and `FiriRateLimitError` as subclasses of the existing error type, plus `error_name` on `FiriHTTPError` to expose Firi's machine-readable error code.

## Compatibility

All new constructor parameters are optional and no existing method signature changed. Existing callers are unaffected.

## Testing

36 unit tests (up from 22) plus 3 live integration tests, all passing against `api.firi.com`. `ruff` and `ty` clean.

```
 .gitignore             |   1 +
 CHANGELOG.md           |  35 ++++++-
 README.md              |  72 ++++++++++++++-
 src/firipy/__init__.py |  10 +-
 src/firipy/_hmac.py    |  47 ++++++++++ (new)
 src/firipy/api.py      | 245 +++++++++++++++++++++++++++++++++++++++----------
 tests/test_firipy.py   | 153 ++++++++++++++++++++++++++++++
 tests/test_hmac.py     |  66 +++++++++++++ (new)
 8 files changed, 575 insertions(+), 54 deletions(-)
```
